### PR TITLE
Support a configurable token to protect endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source 'https://rubygems.org'
 
+group :development, :test do
+  gem 'pry-plus-byebug'
+end
+
 # Specify your gem's dependencies in ruby_build_info.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Rack middleware to output build information such as version control, bundled gems, and specified files to JSON.
 
-## Installation
+## Installation / Usage
 
 Add this line to your application's Gemfile:
 
@@ -15,22 +15,23 @@ And then execute:
 Or install it yourself as:
 
     $ gem install ruby_build_info
-    
-In your `config\environment\development.rb` or environment file of your choosing*:
-    
+
+In your `config\environment\development.rb` or environment file of your choosing:
+
     config.middleware.use(RubyBuildInfo::Middleware)
 
-By default this will output Git revision, and output of `bundle show`.
+By default this will output Git revision if available, and output of `bundle show`.
 
 You can specify an array optional file paths, such as version files.
 
     config.middleware.use(RubyBuildInfo::Middleware, file_paths: ['../custom_file_1', '../custom_file_2'])
 
-*Unless it's production.rb - then I don't condone that.
+You can also provide an optional token in your environment file. When provided, you must pass the token as a parameter to access the endpoint.
 
-## Usage
+    config.middleware.use(RubyBuildInfo::Middleware, token: 'foo')
+    http:://localhost:3000/build_info?token=foo
 
-Go to /build_info in your Ruby application to see output.
+Go to `/build_info` in your Ruby application to see output, supplying `token` paramater if configured.
 
 ## Example Output
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,9 @@
-# 1.0.0
+# 1.1.0
+
+### Changes
+  * Support to protect endpoint by configuring a token.
+
+# 1.0.0 / 1.0.1
 
 ### Changes
   * Initial release

--- a/lib/ruby_build_info/middleware.rb
+++ b/lib/ruby_build_info/middleware.rb
@@ -5,12 +5,16 @@ module RubyBuildInfo
     def initialize(app, options = {})
       @app = app
       @file_paths = options[:file_paths]
+      @token = options[:token]
     end
 
     def call(env)
       if env['PATH_INFO'] == '/build_info'
+        @env = env
+        return @app.call(env) unless token_valid?
+
         @build_info = {}
-        @build_info[:git] = git_revision if git_revision
+        @build_info[:git] = git_revision unless git_revision.empty?
         read_file_paths
         rails_info
         @build_info[:gems] = bundle_show
@@ -32,7 +36,7 @@ module RubyBuildInfo
     end
 
     def read_file_paths
-      unless @file_paths.nil?
+      if @file_paths
         @file_paths.each do |file|
           raise "File does not exist: #{file}" unless File.exist? file
           @build_info[file] = `less #{file}`
@@ -40,11 +44,31 @@ module RubyBuildInfo
       end
     end
 
+    def params
+      query_string = @env['QUERY_STRING']
+      return nil if query_string.nil?
+      Hash[query_string.split('&').map{ |q| q.split('=') }]
+    end
+
+    def rails_defined?
+      defined? Rails
+    end
+
     def rails_info
-      if defined? Rails
+      if rails_defined?
         result = Rails::Info.properties
         @build_info['Rails::Info'] = Hash[result]
       end
+    end
+
+    def token_param
+      params['token'] if params
+    end
+
+    def token_valid?
+      return true if @token.nil?
+      return false if token_param.nil?
+      token_param == @token
     end
   end
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/info'
 
 describe RubyBuildInfo::Middleware do
   subject{ described_class.new(app) }
@@ -14,6 +15,7 @@ describe RubyBuildInfo::Middleware do
   before do
     allow(subject).to receive(:bundle_show).and_return('bundle show')
     allow(subject).to receive(:git_revision).and_return('git revision')
+    allow(subject).to receive(:rails_defined?).and_return false
   end
 
   describe 'unrecognized path' do
@@ -24,17 +26,43 @@ describe RubyBuildInfo::Middleware do
   end
 
   describe '/build_info' do
-    before do
-      @response = server.get('/build_info')
+    let(:example_response) { "{\n  \"git\": \"git revision\",\n  \"gems\": \"bundle show\"\n}" }
+
+    context 'when a token configured' do
+      subject{ described_class.new(app, token: 'foo') }
+      let(:server){ Rack::MockRequest.new(subject) }
+
+      it 'outputs build info when token matches param' do
+        @response = server.get('/build_info?token=foo&param2=value2')
+        expect(@response.body).to_not eq 'Foo'
+        expect(@response.body).to eq example_response
+        expect(@response.status). to eq 200
+      end
+
+      it 'does not output build info when token does not match param' do
+        @response = server.get('/build_info?param1=value1&token=bar')
+        expect(@response.body).to eq 'Foo'
+        expect(@response.body).to_not eq example_response
+        expect(@response.status). to eq 200
+      end
     end
 
-    it 'outputs build info' do
-      expect(@response.body).to_not eq 'Foo'
-      expect(@response.body).to eq "{\n  \"git\": \"git revision\",\n  \"gems\": \"bundle show\"\n}"
-    end
+    context 'when a token is not configured' do
+      subject{ described_class.new(app) }
+      let(:server){ Rack::MockRequest.new(subject) }
 
-    it 'returns HTTP status 200' do
-      expect(@response.status). to eq 200
+      before do
+        @response = server.get('/build_info')
+      end
+
+      it 'outputs build info' do
+        expect(@response.body).to_not eq 'Foo'
+        expect(@response.body).to eq example_response
+      end
+
+      it 'returns HTTP status 200' do
+        expect(@response.status). to eq 200
+      end
     end
   end
 
@@ -62,28 +90,27 @@ describe RubyBuildInfo::Middleware do
       let(:server){ Rack::MockRequest.new(subject) }
 
       it 'returns content of the file' do
+        expected_response = "{\n  \"git\": \"git revision\",\n  \"./spec/support/platform_version\": \"1.2.3\\n\",\n  \"gems\": \"bundle show\"\n}"
         @response = server.get('/build_info')
-        expect(@response.body).to eq "{\n  \"git\": \"git revision\",\n  \"./spec/support/platform_version\": \"1.2.3\\n\",\n  \"gems\": \"bundle show\"\n}"
+        expect(@response.body).to eq expected_response
       end
     end
   end
 
   describe 'Rails::Info' do
-    before do
-      @response = server.get('/build_info')
-    end
-
     context 'when rails is not defined' do
       it 'does not output rails info' do
+        @response = server.get('/build_info')
         expect(@response.body).to_not include "Rails::Info"
       end
     end
 
     context 'when rails is defined' do
-      xit 'outputs rails info' do
-        rails = double('Rails', :env => :production)
-        Object.send(:const_set, :Rails, rails)
-        expect(Rails).to receive(:env).and_return('production')
+      before do
+      end
+      it 'outputs rails info' do
+        allow(subject).to receive(:rails_defined?).and_return true
+        @response = server.get('/build_info')
         expect(@response.body).to include "Rails::Info"
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'pry-rescue/rspec'
+
 RSpec.configure do |config|
   config.requires = ['ruby_build_info']
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/info.rb
+++ b/spec/support/info.rb
@@ -1,0 +1,7 @@
+module Rails
+  module Info
+    def self.properties
+      {'key1' => 'value1'}
+    end
+  end
+end


### PR DESCRIPTION
This allows a token to be configured in the environment configuration. This allows you to define whether or not you want to protect the `../build_info` endpoint with a token.

If you do, then you must supply the token as a parameter.
